### PR TITLE
Monitoring service Part 2

### DIFF
--- a/broker/local_broker.py
+++ b/broker/local_broker.py
@@ -130,7 +130,6 @@ class LocalBroker():
                     if not task.is_finished():
                         exit = False
                     else:
-                        self.sys_info.save_task_time(task)
                         self.optimizer.post_optimize_task(task)
                 sleep(self.timeout)
     
@@ -149,7 +148,8 @@ class LocalBroker():
                         try:
                             started_tasks.remove((task, host))
                             host.task_completed(task)
-                            self.sys_info.save_task_time(task)
+                            if self.sys_info is not None:
+                                self.sys_info.save_task_time(task)
                         except ValueError:
                             logging.error("[MonitorStartedTasks] Could not remove task '{}' from host '{}'".format(task.name, host.hostname))
                 sleep(self.timeout)

--- a/broker/local_broker.py
+++ b/broker/local_broker.py
@@ -220,7 +220,6 @@ class LocalBroker():
         for host in self.get_available_hosts():
             usage = self.sys_info.get_usage(host.hostname)
             score = (100 - usage[InfoKeys.SYSTEM_CPU]) * task.cpu_weight + (100 - usage[InfoKeys.SYSTEM_MEMORY]) * task.memory_weight
-            print(f"{host.hostname}: {usage[InfoKeys.SYSTEM_CPU]} | {usage[InfoKeys.SYSTEM_MEMORY]} => {score}")
             if best_machine is None or score > best_score:
                 best_machine = host
                 best_score = score

--- a/broker/local_broker.py
+++ b/broker/local_broker.py
@@ -10,10 +10,15 @@ import sys
 import lib.info_server as info_server
 from lib.qstat_parser import qstat_parse
 from lib.common import InfoKeys
+from threading import Thread, Event
 
 signal.signal(signal.SIGINT, signal_handler)
 
 class LocalBroker():
+    # Any scheduling method that uses the monitoring service must be added here
+    # You can also use this to monitor a scheduling method using the monitoring servicee, results are in performance.log
+    SCHEDULE_USING_SYS_INFO = ["short-tasks", "mixed-tasks"]
+
     def __init__(self, config, optimizer):
         logging.info("Creating Local Broker Object")
         self.config = config
@@ -28,7 +33,7 @@ class LocalBroker():
         self.job_num = 0
         # create hosts
         self.init_workspace()
-        if self.scheduling_method == 'short-tasks':
+        if self.scheduling_method in LocalBroker.SCHEDULE_USING_SYS_INFO:
             self.sys_info = info_server.SystemInfoServer()
         else:
             self.sys_info = None
@@ -125,8 +130,48 @@ class LocalBroker():
                     if not task.is_finished():
                         exit = False
                     else:
+                        self.sys_info.save_task_time(task)
                         self.optimizer.post_optimize_task(task)
                 sleep(self.timeout)
+    
+    # this and schedule_tasks do the same thing, call the scheduling method for each task
+    # what this function does on top of that is limit how many tasks are scheduled by the number of CPUS defined 
+    # in the configuration of each machine
+    def limited_schedule_tasks(self, tasks=[]):
+        started_tasks = []
+        done = Event()
+        def monitor_started_tasks():
+            nonlocal started_tasks
+            while not done.is_set() or len(started_tasks) > 0:
+                for task, host in started_tasks:
+                    task.mark_if_finished()
+                    if task.finished:
+                        try:
+                            started_tasks.remove((task, host))
+                            host.task_completed(task)
+                            self.sys_info.save_task_time(task)
+                        except ValueError:
+                            logging.error("[MonitorStartedTasks] Could not remove task '{}' from host '{}'".format(task.name, host.hostname))
+                sleep(self.timeout)
+
+        started_tasks_monitor = Thread(target=monitor_started_tasks)
+        started_tasks_monitor.start()
+
+        while len(tasks) > 0:
+            task = tasks.pop(0)
+            if task.is_ready(tasks):
+                while not any(self.get_available_hosts()):
+                    sleep(self.timeout)
+                host = self.schedule_task(task)
+                started_tasks.append((task, host))
+        
+        done.set()
+        started_tasks_monitor.join()
+                    
+    def get_available_hosts(self):
+        for host in self.machines:
+            if not host.is_full():
+                yield host
 
     def schedule_task(self, task):
         logging.info('\nScheduling task ' + task.to_string())
@@ -136,26 +181,29 @@ class LocalBroker():
         #call the preoptimize
         self.optimizer.pre_optimize_task(task)
 
-        # now we are into the task folder
-        if self.scheduling_method == 'min-min':
-            self.min_min_schedule(task)
-        elif self.scheduling_method == 'work-queue':
-            self.work_queue_schedule(task)
-        elif self.scheduling_method == 'max-min':
-            self.max_min_schedule(task)
-        elif self.scheduling_method == 'long-tasks':
-            self.long_tasks_load_schedule(task)
-        elif self.scheduling_method == 'short-tasks':
-            self.short_task_load_schedule(task)
-        else:
-            self.priority_schedule(task)
-
         # mark task as not ready because you already scheduled it
         task.scheduled = True
+
+        # now we are into the task folder
+        if self.scheduling_method == 'min-min':
+            return self.min_min_schedule(task)
+        elif self.scheduling_method == 'work-queue':
+            return self.work_queue_schedule(task)
+        elif self.scheduling_method == 'max-min':
+            return self.max_min_schedule(task)
+        elif self.scheduling_method == 'long-tasks':
+            return self.long_tasks_load_schedule(task)
+        elif self.scheduling_method == 'short-tasks':
+            return self.short_task_load_schedule(task)
+        elif self.scheduling_method == 'mixed-tasks':
+            return self.mixed_tasks_schedule(task)
+        else:
+            return self.priority_schedule(task)
 
     def min_min_schedule(self, task):
         mach_id = self.get_fastest_min_host(task)
         self.machines[mach_id].send_task(task)
+        return self.machines[mach_id]
 
     def max_min_schedule(self, task):
         pass
@@ -169,9 +217,10 @@ class LocalBroker():
     def short_task_load_schedule(self, task):
         best_machine, best_score = None, None
         current_usage = {}
-        for host in self.machines:
+        for host in self.get_available_hosts():
             usage = self.sys_info.get_usage(host.hostname)
             score = (100 - usage[InfoKeys.SYSTEM_CPU]) * task.cpu_weight + (100 - usage[InfoKeys.SYSTEM_MEMORY]) * task.memory_weight
+            print(f"{host.hostname}: {usage[InfoKeys.SYSTEM_CPU]} | {usage[InfoKeys.SYSTEM_MEMORY]} => {score}")
             if best_machine is None or score > best_score:
                 best_machine = host
                 best_score = score
@@ -179,15 +228,16 @@ class LocalBroker():
         # we receive usage stats periodically, so we add the estimated task length to the current score
         # so that if another task is scheduled before the usage is updated we won't end up
         # scheduling on the same best_machine (this is usually the case for the first scheduled tasks)
-        self.sys_info.local_update_usage(host.hostname, task)
-        
+        self.sys_info.local_update_usage(best_machine.hostname, task)
+
         best_machine.send_task(task)
+        return best_machine
     
     # uses 'qstat' to find information about the system
     # because qstat is not updated often, this policy yields best results with long tasks
     def long_tasks_load_schedule(self, task):
         best_machine = None
-        all_machines_usage = [(host, qstat_parse(host.hostname)) for host in self.machines]
+        all_machines_usage = [(host, qstat_parse(host.hostname)) for host in self.get_available_hosts()]
         all_machines_usage = list(filter(lambda elem: elem[1] is not None, all_machines_usage))
 
         if len(all_machines_usage) == 0:
@@ -196,15 +246,22 @@ class LocalBroker():
         elif len(all_machines_usage) == 1:
             best_machine = all_machines_usage[0][0]
         else:
-            max_mem_free = max(elem[1]['mem_free'] for elem in all_machines_usage)
-            min_mem_free = min(elem[1]['mem_free'] for elem in all_machines_usage)
-            diff_mem_free = max_mem_free - min_mem_free
             best_score = None
             for host, usage in all_machines_usage:
-                normalized_mem_free = (usage['mem_free'] - min_mem_free) / diff_mem_free
-                score = (1 - usage['np_load_avg'] * task.cpu_weight) + normalized_mem_free * task.memory_weight
+                score = (100 - usage['np_load_avg']) * task.cpu_weight + (100 - usage['mem_used']) * task.memory_weight
                 if best_machine is None or score > best_score:
                     best_machine, best_score = host, score
         
         logging.info("[long-tasks policy] Schedule on " + best_machine.hostname)
         best_machine.send_task(task)
+        
+        return best_machine
+    
+    def mixed_tasks_schedule(self, task):
+        time_estimate = self.sys_info.get_task_time_estimate(task.name)
+        # tasks that are 5 minutes or longer can be scheduled using qstat information
+        if time_estimate is not None and time_estimate > 5*60:
+            print(f"Long task detected: {task.name}")
+            return self.long_tasks_load_schedule(task)
+        else:
+            return self.short_task_load_schedule(task)

--- a/configs/broker-config.json
+++ b/configs/broker-config.json
@@ -25,5 +25,6 @@
   "rootfs" : "~/COSMOS-Framework/task_examples/pi_computing",
   "workspace" : "~/workspace",
   "propagate_workspace" : "True",
-  "timeout" : 10
+  "timeout" : 10,
+  "info_server_port" : 28972
 }

--- a/lib/common.py
+++ b/lib/common.py
@@ -10,3 +10,4 @@ class InfoKeys:
     TASK_MEM_INTENSIVE = "m_intensive"
     TASK_COUNT = "count"
     HOSTNAME = "hostname"
+    TIMESTAMP = "timestamp"

--- a/lib/custom_loggers.py
+++ b/lib/custom_loggers.py
@@ -1,4 +1,4 @@
-import logging
+import logging, os
 
 def setup_custom_logger(name, log_file, formatter, level=logging.INFO):
     handler = logging.FileHandler(log_file)
@@ -12,4 +12,11 @@ def setup_custom_logger(name, log_file, formatter, level=logging.INFO):
 
 simple_formatter = logging.Formatter("%(message)s")
 
-perf_logger = setup_custom_logger("PerfLogger", "performance.log", simple_formatter)
+perf_logger_file = "performance.log"
+i = 0
+while os.path.exists(perf_logger_file):
+    i += 1
+    perf_logger_file = f"performance{i}.log"
+
+print(f"Performance logging to: {perf_logger_file}")
+perf_logger = setup_custom_logger("PerfLogger", perf_logger_file, simple_formatter)

--- a/lib/custom_loggers.py
+++ b/lib/custom_loggers.py
@@ -1,0 +1,15 @@
+import logging
+
+def setup_custom_logger(name, log_file, formatter, level=logging.INFO):
+    handler = logging.FileHandler(log_file)
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.addHandler(handler)
+
+    return logger
+
+simple_formatter = logging.Formatter("%(message)s")
+
+perf_logger = setup_custom_logger("PerfLogger", "performance.log", simple_formatter)

--- a/lib/host.py
+++ b/lib/host.py
@@ -1,11 +1,8 @@
-import logging
-import sys
-import os
-import subprocess
+import logging, json, sys, os, subprocess, threading
 from multiprocessing import Process
-import threading
 import lib.info_server as info_server
 from broker.task import Task
+from lib.custom_loggers import perf_logger
 
 def exec_func(**kwargs):
     logging.info("Executing task: " + str(kwargs))
@@ -84,7 +81,7 @@ class Host():
                          '--report_timeout {} ' \
                          .format(self.python_exec,
                                  info_server.INFO_SERVICE_HOSTNAME,
-                                 info_server.INFO_SERVICE_PORT,
+                                 info_server.SystemInfoServer.INFO_SERVICE_PORT,
                                  self.hostname,
                                  Task.TASK_PREFIX,
                                  self.usage_report_timeout)

--- a/lib/host.py
+++ b/lib/host.py
@@ -159,6 +159,7 @@ class Host():
         else:
             logging.error("Unknown host type: {}".format(self.type))
             sys.exit(1)
+        task.mark_start_time()
 
     def send_task(self, task):
         """
@@ -175,7 +176,7 @@ class Host():
         self.exec_task(task)
 
         self.running_tasks[task.get_id()] = task
-        logging.info('\tTask: {0} is running now running\n'.format(task.get_id()))
+        logging.info('\tTask: {0} is now running\n'.format(task.get_id()))
 
     def tasks_join(self):
         for task in self.running_tasks:
@@ -187,8 +188,9 @@ class Host():
         This should be called when a process joins
         '''
         self.used_cpus -= 1
-        self.load -= task['length']
-        #self.running_tasks.remove(task)
+        self.load -= task.length
+        del self.running_tasks[task.get_id()]
+        # self.running_tasks.remove(task)
 
     def to_string(self):
         res = ""
@@ -205,3 +207,6 @@ class Host():
 		"""
         ret = float(self.load + task.get_length()) / float(self.processing_power)
         return ret
+
+    def is_full(self):
+        return self.used_cpus >= self.cpus

--- a/lib/host_info_service.py
+++ b/lib/host_info_service.py
@@ -1,9 +1,6 @@
 import psutil as ps
-import socket
-import argparse
-import select
-import os
-import json
+import socket, select
+import argparse, os, json, struct
 from common import InfoKeys
 
 parser = argparse.ArgumentParser()
@@ -76,7 +73,7 @@ class SystemInfoService(object):
         return {**system_load, InfoKeys.PER_TASK_USAGE: per_task_usage}
 
 def pack_message(message):
-    return bytes([len(message)]) + message.encode()
+    return struct.pack("I", len(message)) + message.encode()
 
 def send_message(message, server):
     msg_bytes = pack_message(json.dumps(message))

--- a/lib/host_info_service.py
+++ b/lib/host_info_service.py
@@ -23,18 +23,18 @@ class SystemInfoService(object):
 
     @property
     def _tasks_pids(self):
-        print("ps_cmd: {}".format(self._procs_pid_cmd))
         raw = os.popen(self._procs_pid_cmd).read()
         pids = [int(pid) for pid in filter(lambda p: len(p) > 0, raw.split('\n'))]
 
-        print("pids: {}".format(str(pids)))
         return pids
     
     @property
     def _processes(self):
         for pid in self._tasks_pids:
             try:
-                yield ps.Process(pid)
+                proc = ps.Process(pid)
+                name = proc.name()
+                yield proc, name
             except ps.NoSuchProcess:
                 pass
     
@@ -45,15 +45,19 @@ class SystemInfoService(object):
 
     def _get_resources_used(self):
         per_task_usage = {}
-        for proc in self._processes:
-            name = proc.name().replace(self.task_prefix, "")
-            if name not in per_task_usage:
-                per_task_usage[name] = {InfoKeys.TASK_CPU: 0, InfoKeys.TASK_MEMORY: 0, InfoKeys.TASK_COUNT: 0, InfoKeys.TASK_MEM_INTENSIVE: False}
-            
-            cpu_usage, memory_usage = self._get_process_usage(proc)
-            per_task_usage[name][InfoKeys.TASK_CPU] += cpu_usage
-            per_task_usage[name][InfoKeys.TASK_MEMORY] += memory_usage
-            per_task_usage[name][InfoKeys.TASK_COUNT] += 1
+        for proc, full_name in self._processes:
+            name = full_name.replace(self.task_prefix, "")
+            try:
+                if name not in per_task_usage:
+                    per_task_usage[name] = {InfoKeys.TASK_CPU: 0, InfoKeys.TASK_MEMORY: 0, InfoKeys.TASK_COUNT: 0, InfoKeys.TASK_MEM_INTENSIVE: False}
+                
+                cpu_usage, memory_usage = self._get_process_usage(proc)
+                per_task_usage[name][InfoKeys.TASK_CPU] += cpu_usage
+                per_task_usage[name][InfoKeys.TASK_MEMORY] += memory_usage
+                per_task_usage[name][InfoKeys.TASK_COUNT] += 1
+            except ps.NoSuchProcess:
+                if name in per_task_usage:
+                    del per_task_usage[name]
 
         for task_name in per_task_usage.keys():
             current_entry = per_task_usage[task_name]

--- a/lib/qstat_parser.py
+++ b/lib/qstat_parser.py
@@ -81,6 +81,9 @@ def qstat_parse(queue):
                 current_machine[USED_MEMORY_KEY] /= current_machine[TOTAL_MEMORY_KEY]
                 del current_machine[TOTAL_MEMORY_KEY]
 
+    if current_machine is not None:
+        for k in WANTED_STATS:
+            stats[k] += current_machine[k]
     
     if n_machines < 1:
         log("No machines found in queue {!r}".format(queue if queue is not None else "all queues"))

--- a/lib/qstat_parser.py
+++ b/lib/qstat_parser.py
@@ -2,7 +2,11 @@ import os, logging
 
 QSTAT_CMD = "qstat -F"
 QUEUE_ARG = "-q {}"
-WANTED_STATS = {"hl:mem_free", "hl:np_load_avg"}
+USED_MEMORY_KEY = "hl:mem_used"
+WANTED_STATS = {USED_MEMORY_KEY, "hl:np_load_avg"}
+
+TOTAL_MEMORY_KEY = "hl:mem_total"
+UTIL_STATS = {TOTAL_MEMORY_KEY}
 
 def _get_raw(queue):
     cmd = [QSTAT_CMD]
@@ -14,33 +18,69 @@ def _get_raw(queue):
 def log(msg):
     logging.info("[QStatParser] {}".format(msg))
 
+def extract_value(raw_value):
+    try:
+        if raw_value[-1] == "G":
+            return float(raw_value[:-1]) * 1024
+        elif raw_value[-1] == 'M':
+            return float(raw_value[:-1])
+        elif raw_value[-1] == 'K':
+            return float(raw_value[:-1]) / 1024
+        else:
+            return float(raw_value)
+    except ValueError:
+        pass
+
+    return None
+
+def is_new_machine(line):
+    # line filled with '-' marks a new machine
+    return line == len(line) * '-'
+
 def qstat_parse(queue):
     raw = _get_raw(queue)
     stats = {k: 0 for k in WANTED_STATS}
     n_machines = 0
+    current_machine = None
+    new_machine_marker = False
     for line in raw.split("\n"):
         line = " ".join(line.split())  # remove consecutive whitespaces
-        if len(line) < 1 or line[0] == '-' or line[0] == '#':
+        if len(line) < 1 or line[0] == '#':
+            continue
+        if is_new_machine(line):
+            new_machine_marker = True
+            if current_machine is not None:
+                for k in WANTED_STATS:
+                    stats[k] += current_machine[k]
             continue
         info = line.split()
         if len(info) < 1:
             continue
-        elif len(info) > 1:  # first line for new machine
-            n_machines += 1
-            current_machine = info[0]
+        elif len(info) > 1:
+            if new_machine_marker:
+                # first line for a new machine (after the line filled with '-')
+                n_machines += 1
+                current_machine = {}
+                new_machine_marker = False
+            else:
+                # line showing info for a running job
+                continue
         else:  # some stat we may want
             try:
                 k, v = info[0].split("=")
             except ValueError:
                 log("Line {!r} isn't in the expected format 'key=value".format(info[0]))
-            if k in WANTED_STATS:
-                try:
-                    if v[-1] == "G":
-                        stats[k] += float(v[:-1])
-                    else:
-                        stats[k] += float(v)
-                except ValueError:
-                    log("For line {!r} => key {!r}, value {!r} could not be converted to float!".format(info[0], k, v))
+            if k in WANTED_STATS or k in UTIL_STATS:
+                val = extract_value(v)
+                if val is None:
+                    log("For line {!r} => key {!r}, value {!r} could not be parsed!".format(info[0], k, v))
+                    continue
+                current_machine[k] = val
+            
+            if TOTAL_MEMORY_KEY in current_machine and USED_MEMORY_KEY in current_machine:
+                current_machine[USED_MEMORY_KEY] /= current_machine[TOTAL_MEMORY_KEY]
+                del current_machine[TOTAL_MEMORY_KEY]
+
     
     if n_machines < 1:
         log("No machines found in queue {!r}".format(queue if queue is not None else "all queues"))


### PR DESCRIPTION
- In configuratia broker-ului trebuie definit un port pentru serviciul de monitorizare cu daemoni. Cheia folosita este `info_server_port: <port>`. Am adaugat by default in `broker-config.json` ca exemplu
- Am schimbat scriptul care parseaaza qstat destul de mult. Inainte intorcea informatiile intr-un format diferit (memoria libera in gigabiti si utilizarea procesorului in procente). Problema era cu memoria, sistemul bazat pe daemoni intoarce procentul de utilizare petnru ambele resurse (memorie si cpu), asa ca am facut si parser-ul sa intoarca aceleasi informatii. Am facut asta ca sa folosesc aceeasi formula pentru scorul fiecarei masini.
- Am adaugat in local broker o functie numita `limited_schedule_tasks` care planifica task-urile in limita in care sunt CPU-uri disponibile pe masinile configurate. Nu am facut vreun flag in configuratii care sa schimbe intre `schedule_tasks` si `limited_schedule_tasks` pentru ca nu stiu unde ar fi mai bine sa il adaug sau daca e nevoie de ambele functii. Poate ar fi mai bine sa fie o alta clasa care mosteneste LocalBroker si implementeaza schedule_tasks in mod diferit.
- Din cauza functiei de mai sus am facut ca toate metodele de planificare sa intoarca masina pe care au planificat task-ul.
- Am adaugat si o metoda de a masura din framework cat dureaza executia fiecarui task. De mentionat aici ca fiind o masuratoare facuta in framework, in cazul in care job-urile sunt executate cu `qsub`, va intra la socoteala si timpul in care job-ul sta in coada, nu doar timpul petrecut pe masina pe care a fost planificat.
- Alte fixuri mici.